### PR TITLE
fixes #20 - include skipped Postman assertion step write individual test status

### DIFF
--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -161,7 +161,9 @@ class GenerateCtrfReport {
               status:
                 assertion.error != null
                   ? ('failed' as CtrfTestState)
-                  : assertion.skipped ? ('skipped' as CtrfTestState) : ('passed' as CtrfTestState),
+                  : assertion.skipped
+                    ? ('skipped' as CtrfTestState)
+                    : ('passed' as CtrfTestState),
               duration: execution.response.responseTime,
             }
 

--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -161,7 +161,7 @@ class GenerateCtrfReport {
               status:
                 assertion.error != null
                   ? ('failed' as CtrfTestState)
-                  : ('passed' as CtrfTestState),
+                  : assertion.skipped ? ('skipped' as CtrfTestState) : ('passed' as CtrfTestState),
               duration: execution.response.responseTime,
             }
 


### PR DESCRIPTION
Small change, we should not only count skipped tests for summary, but also indicated what exact tests were skipped 