### PR TITLE
Update generate-report.ts

### DIFF
--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -162,7 +162,7 @@ class GenerateCtrfReport {
                   : assertion.skipped
                     ? ('skipped' as CtrfTestState)
                     : ('passed' as CtrfTestState),
-              duration: execution.response.responseTime,
+              duration: execution.response ? execution.response.responseTime : 0,
             }
 
             if (this.reporterConfigOptions.minimal === false) {


### PR DESCRIPTION
If no response time is sent, set the response time to 0 so we don't throw a stacktrace with 'global is not defined'