### PR TITLE
Handle test reporting when NewmanRunExecution.response is null

### DIFF
--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -162,7 +162,7 @@ class GenerateCtrfReport {
                   : assertion.skipped
                     ? ('skipped' as CtrfTestState)
                     : ('passed' as CtrfTestState),
-              duration: execution.response.responseTime ?? 0,
+              duration: execution.response?.responseTime ?? 0,
             }
 
             if (this.reporterConfigOptions.minimal === false) {


### PR DESCRIPTION
This PR handles fixes the error when the `NewmanRunExecution.response` property is null. The reporter reads this property to find the test duration.

The `response` property is not marked as nullable in the Newman type definitions. However, it will be null if there was no response to the HTTP request. I found a few cases where this can happen:
- TLS certificate error (this happen for me when I run in a Docker container because my company's firewall performs TLS traffic inspection. The company's root cert is not installed in the container, so the connection cannot be established).
- DNS lookup error
- TCP connection timeout

You can easily cause this error with by running the following Newman collection with the ctrf reporter:

```
  "info": {
    "name": "Example Collection with a single GET request",
    "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
  },

  "item": [{
    "name": "A simple GET request",
    "event": [{
      "listen": "test",
      "script": {
        "type": "text/javascript",
        "exec": ["tests['response code is 200'] = (responseCode.code === 200);"]
      }
    }],
    "request": {
      "url": "https://fake-website-with-no-dns.xyz",
      "method": "GET"
    }
  }]
}

```

When there is no response object associated with a test, the reporter defaults to showing duration of 0. This is misleading, because even when Newman cannot establish a connection while running a test item, the test still takes time. However, Newman doesn't seem to report any sort of test duration in anywhere besides the response object, so I can't find another way to get this value. A possible workaround would be to independently track request start and end events in the reporter while the collection is executing. I haven't implemented this because it would add a lot of complexity to fix a small issue.

Fixes #19 